### PR TITLE
Adding (some) conic constraints.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,8 @@ julia = "1.10"
 Juniper = "0.9.3"
 Ipopt = "1.9.0"
 InfiniteOpt = "0.6.3"
+Hypatia = "0.10"
+Pajarito = "0.8"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -28,6 +30,8 @@ HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 Juniper = "2ddba703-00a4-53a7-87a5-e8b9971dde84"
+Hypatia = "b99e6be6-89ff-11e8-14f8-45c827f4f8f2"
+Pajarito = "2f354839-79df-5901-9f0a-cdb2aac6fe30"
 
 [targets]
-test = ["Aqua", "HiGHS", "Test", "Juniper", "Ipopt", "InfiniteOpt"]
+test = ["Aqua", "HiGHS", "Test", "Juniper", "Ipopt", "InfiniteOpt", "Hypatia", "Pajarito"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.6.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [weakdeps]
@@ -16,6 +17,7 @@ InfiniteDisjunctiveProgramming = "InfiniteOpt"
 [compat]
 Aqua = "0.8"
 JuMP = "1.18"
+LinearAlgebra = "1"
 Reexport = "1"
 julia = "1.10"
 Juniper = "0.9.3"

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The following reformulation methods are currently supported:
 2. [Hull](https://optimization.cbe.cornell.edu/index.php?title=Disjunctive_inequalities#Convex-Hull_Reformulation[1][2]): The `Hull` struct is created with the following optional arguments:
 
     - `value`: `ϵ` value to use when reformulating quadratic or nonlinear constraints via the perspective function proposed by [Furman, et al. [2020]](https://link.springer.com/article/10.1007/s10589-020-00176-0). Default: `1e-6`. `ϵ` values are currently global to the model. Constraint specific tolerances can be supported in future releases.
+    - `quadratic`: Reformulation to use for quadratic disjunct constraints. Default: `:epsilon` (the ε-approximated perspective function above). The exact hull reformulations of [Gusev & Bernal Neira [2025]](https://arxiv.org/abs/2508.16093) are available as `:exact` (automatically uses CEHR for constraints with a convex quadratic part and GEHR otherwise), `:gehr`, `:cehr`, and `:cehr_conic` (CEHR with the cone written out explicitly as a rotated second-order cone for solvers that use cones natively).
 
 3. [Indicator](https://jump.dev/JuMP.jl/stable/manual/constraints/#Indicator-constraints): This method reformulates each disjunct constraint into an indicator constraint with the Boolean reformulation counterpart of the Logical variable used to define the disjunct constraint.
 
@@ -191,6 +192,22 @@ The following reformulation methods are currently supported:
     - `seperation_tolerance`: Convergence tolerance for the separation problem objective. Default: `1e-6`.
     - `final_reform_method`: Reformulation method to apply after cutting plane iterations. Default: `BigM()`.
     - `M_value`: Big-M value to use in the relaxed Big-M reformulation during iterations. Default: `1e9`.
+
+## Conic Constraints
+
+Disjunct constraints can also be defined with the conic sets `SecondOrderCone`, `RotatedSecondOrderCone`, `MOI.ExponentialCone`, and `MOI.PowerCone`. Big-M reformulates these by relaxing the constraint function along a fixed interior direction of the cone, and Hull produces the exact conic hull of [Bernal Neira & Grossmann [2021]](https://arxiv.org/abs/2109.09657).
+
+```julia
+using DisjunctiveProgramming
+
+model = GDPModel()
+@variable(model, -5 <= x[1:2] <= 5)
+@variable(model, 0 <= t <= 10)
+@variable(model, Y[1:2], Logical)
+@constraint(model, [t; x] in SecondOrderCone(), Disjunct(Y[1]))          # t >= ‖x‖
+@constraint(model, [x[1], 1, t] in MOI.ExponentialCone(), Disjunct(Y[2])) # t >= exp(x[1])
+@disjunction(model, Y)
+```
 
 ## Infinite-Dimensional GDP
 To model disjunctions, logical variables, and logical constraints with infinite-dimensional optimization problems (e.g., dynamic and stochastic optimization), DisjunctiveProgramming is also compatible with [InfiniteOpt.jl](https://github.com/infiniteopt/InfiniteOpt.jl). For this, the syntax is largely the same, users simply need to import `InfiniteOpt` and use `InfiniteGDPModel`. They also can use `InfiniteLogical` to declare infinite logical variables as shown below:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -167,6 +167,8 @@ The following reformulation methods are currently supported:
 
 3. [Indicator](https://jump.dev/JuMP.jl/stable/manual/constraints/#Indicator-constraints): This method reformulates each disjunct constraint into an indicator constraint with the Boolean reformulation counterpart of the Logical variable used to define the disjunct constraint. This is invoked with [`Indicator`](@ref).
 
+Disjunct constraints can also be defined with the conic sets `SecondOrderCone`, `RotatedSecondOrderCone`, `MOI.ExponentialCone`, and `MOI.PowerCone`; these are supported by the [`BigM`](@ref) and [`Hull`](@ref) reformulations, where the hull of a conic constraint is exact. Exact hull reformulations for quadratic disjunct constraints (GEHR/CEHR) are available via the `quadratic` keyword argument of [`Hull`](@ref).
+
 ## Release Notes
 
 Prior to `v0.4.0`, the package did not leverage the JuMP extension capabilities and was not as robust. For these earlier releases, refer to [Perez, Joshi, and Grossmann, 2023](https://arxiv.org/abs/2304.10492v1) and the following [JuliaCon 2022 Talk](https://www.youtube.com/watch?v=AMIrgTTfUkI).

--- a/ext/InfiniteDisjunctiveProgramming.jl
+++ b/ext/InfiniteDisjunctiveProgramming.jl
@@ -38,6 +38,70 @@ function DP.requires_disaggregation(vref::InfiniteOpt.GeneralVariableRef)
     return !_is_parameter(vref)
 end
 
+# Bound info for parameter refs in disjunct constraints: parameter
+# functions report their support extrema, finite parameters a point,
+# other parameters their domain bounds. Returns nothing for
+# variables.
+function _parameter_bound_info(
+    vref::InfiniteOpt.GeneralVariableRef
+    )::Union{Nothing, Tuple{Float64, Float64}}
+    _is_parameter(vref) || return nothing
+    dvref = InfiniteOpt.dispatch_variable_ref(vref)
+    if dvref isa InfiniteOpt.ParameterFunctionRef
+        prefs = InfiniteOpt.parameter_list(dvref)
+        length(prefs) == 1 || return (-Inf, Inf)
+        supports = InfiniteOpt.supports(first(prefs))
+        isempty(supports) && return (-Inf, Inf)
+        func = InfiniteOpt.raw_function(dvref)
+        func_values = [func(s) for s in supports]
+        return (minimum(func_values), maximum(func_values))
+    elseif dvref isa InfiniteOpt.FiniteParameterRef
+        value = InfiniteOpt.parameter_value(dvref)
+        return (value, value)
+    end
+    lb = JuMP.has_lower_bound(vref) ? JuMP.lower_bound(vref) : -Inf
+    ub = JuMP.has_upper_bound(vref) ? JuMP.upper_bound(vref) : Inf
+    return (lb, ub)
+end
+
+function DP.set_variable_bound_info(
+    vref::InfiniteOpt.GeneralVariableRef, ::DP.BigM)
+    info = _parameter_bound_info(vref)
+    info === nothing || return info
+    lb = JuMP.has_lower_bound(vref) ? JuMP.lower_bound(vref) : -Inf
+    ub = JuMP.has_upper_bound(vref) ? JuMP.upper_bound(vref) : Inf
+    return lb, ub
+end
+
+# Hull and PSplit require finite bounds that include 0
+function _zero_inclusive_bounds(
+    vref::InfiniteOpt.GeneralVariableRef,
+    info::Union{Nothing, Tuple{Float64, Float64}},
+    method_name::String
+    )::Tuple{Float64, Float64}
+    info === nothing || return (min(0, info[1]), max(0, info[2]))
+    if !JuMP.has_lower_bound(vref) || !JuMP.has_upper_bound(vref)
+        error("Variable $vref must have both lower and upper " *
+              "bounds defined when using the $method_name " *
+              "reformulation.")
+    end
+    return (min(0, JuMP.lower_bound(vref)),
+            max(0, JuMP.upper_bound(vref)))
+end
+
+function DP.set_variable_bound_info(
+    vref::InfiniteOpt.GeneralVariableRef, ::DP.Hull)
+    return _zero_inclusive_bounds(vref,
+        _parameter_bound_info(vref), "Hull")
+end
+
+function DP.set_variable_bound_info(
+    vref::InfiniteOpt.GeneralVariableRef,
+    ::Union{DP.PSplit, DP._PSplit})
+    return _zero_inclusive_bounds(vref,
+        _parameter_bound_info(vref), "PSplit")
+end
+
 function DP.VariableProperties(vref::InfiniteOpt.GeneralVariableRef)
     info = DP.get_variable_info(vref)
     name = JuMP.name(vref)

--- a/src/DisjunctiveProgramming.jl
+++ b/src/DisjunctiveProgramming.jl
@@ -6,6 +6,8 @@ Reexport.@reexport using JuMP
 
 # Use Meta for metaprogramming
 using Base.Meta
+# Convexity checks for the exact quadratic hull reformulations
+import LinearAlgebra
 # Create aliases
 import JuMP.MOI as _MOI
 import JuMP.MOIU.CleverDicts as _MOIUC

--- a/src/bigm.jl
+++ b/src/bigm.jl
@@ -283,9 +283,7 @@ function reformulate_disjunct_constraint(
     method::BigM
 ) where {
     T <: Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
-    S <: Union{_MOI.SecondOrderCone, _MOI.RotatedSecondOrderCone,
-        _MOI.ExponentialCone, _MOI.PowerCone},
-    R
+    S <: _ConicSets, R
 }
     M = method.value
     d = _conic_bigm_direction(con.set)

--- a/src/bigm.jl
+++ b/src/bigm.jl
@@ -251,3 +251,47 @@ function reformulate_disjunct_constraint(
     reform_con_np = JuMP.build_constraint(error, new_func_np, _MOI.Nonpositives(con.set.dimension))
     return [reform_con_nn, reform_con_np]
 end
+
+################################################################################
+#                       BIG-M FOR CONIC CONSTRAINTS
+################################################################################
+# Big-M for `func in K`: add slack `M*(1 - y)*d` along a fixed interior
+# direction `d` of the cone, so `func + M*d in K`.
+
+# SOC: (t, x...) with t >= ||x||.  d = e1 = (1, 0, ...); interior since
+# 1 > ||0|| = 0.  Bumping t alone makes (t + M) >= ||x|| hold for big M.
+_conic_bigm_direction(set::_MOI.SecondOrderCone) =
+    [i == 1 ? 1.0 : 0.0 for i in 1:_MOI.dimension(set)]
+# Rotated SOC: (t, u, x...) with 2*t*u >= ||x||^2, t,u >= 0.  d =
+# (1,1,0,...); interior since 2*1*1 = 2 > 0.  Both t,u must grow so
+# 2(t+M)(u+M) ~ 2*M^2 dominates ||x||^2; bumping one leaves 2*t*0 = 0.
+_conic_bigm_direction(set::_MOI.RotatedSecondOrderCone) =
+    [i <= 2 ? 1.0 : 0.0 for i in 1:_MOI.dimension(set)]
+# Exp cone: (x, y, z) with z >= y*exp(x/y), y >= 0.  d = (0, 1, 2);
+# interior since 2 > 1*exp(0) = 1.  As M grows, exp(x/(y+M)) -> 1 so the
+# RHS ~ y + M ~ M while z grows as 2M; the factor 2 keeps z above it.
+_conic_bigm_direction(::_MOI.ExponentialCone) = [0.0, 1.0, 2.0]
+# Power cone: (x, y, z) with x^a * y^(1-a) >= |z|, x,y >= 0, a the cone
+# exponent.  d = (1,1,0); interior since 1^a * 1^(1-a) = 1 > 0.  Bumping
+# x,y makes (x+M)^a (y+M)^(1-a) ~ M dominate the fixed |z|; z untouched.
+_conic_bigm_direction(::_MOI.PowerCone) = [1.0, 1.0, 0.0]
+
+function reformulate_disjunct_constraint(
+    model::JuMP.AbstractModel,
+    con::JuMP.VectorConstraint{T, S, R},
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::BigM
+) where {
+    T <: Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    S <: Union{_MOI.SecondOrderCone, _MOI.RotatedSecondOrderCone,
+        _MOI.ExponentialCone, _MOI.PowerCone},
+    R
+}
+    M = method.value
+    d = _conic_bigm_direction(con.set)
+    new_func = JuMP.@expression(model, [i=1:_MOI.dimension(con.set)],
+        con.func[i] + M*(1 - bvref)*d[i]
+    )
+    reform_con = JuMP.build_constraint(error, new_func, con.set)
+    return [reform_con]
+end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -207,6 +207,16 @@ function JuMP.build_constraint(
     return _DisjunctConstraint(constr, tag.indicator)
 end
 
+# MOI conic sets handled by the BigM and Hull conic reformulations
+# (Bernal Neira & Grossmann 2021). The affine map A*x - b sits inside
+# the cone; the nonlinearity is carried by the cone itself.
+const _ConicSets = Union{
+    _MOI.SecondOrderCone,
+    _MOI.RotatedSecondOrderCone,
+    _MOI.ExponentialCone,
+    _MOI.PowerCone,
+}
+
 # Allows for building DisjunctConstraints for VectorConstraints since these get parsed differently by JuMP (JuMP changes the set to a MOI.AbstractScalarSet)
 for SetType in (
     JuMP.Nonnegatives, JuMP.Nonpositives, JuMP.Zeros,

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -210,7 +210,10 @@ end
 # Allows for building DisjunctConstraints for VectorConstraints since these get parsed differently by JuMP (JuMP changes the set to a MOI.AbstractScalarSet)
 for SetType in (
     JuMP.Nonnegatives, JuMP.Nonpositives, JuMP.Zeros,
-    _MOI.Nonnegatives, _MOI.Nonpositives, _MOI.Zeros
+    _MOI.Nonnegatives, _MOI.Nonpositives, _MOI.Zeros,
+    JuMP.SecondOrderCone, JuMP.RotatedSecondOrderCone,
+    _MOI.SecondOrderCone, _MOI.RotatedSecondOrderCone,
+    _MOI.ExponentialCone, _MOI.PowerCone
 )
     @eval begin
         @doc """

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -425,14 +425,19 @@ constraints.
   - `:gehr`: always use the General Exact Hull Reformulation.
   - `:cehr`: always use the Conic Exact Hull Reformulation (errors on
     nonconvex quadratic constraints).
+  - `:cehr_conic`: CEHR with the cone written out explicitly as a
+    rotated second-order cone via a spectral factorization of the
+    quadratic part, for solvers that consume cones natively (errors on
+    nonconvex quadratic constraints).
 """
 struct Hull{T} <: AbstractReformulationMethod
     value::T
     quadratic::Symbol
     function Hull(ϵ::T = 1e-6; quadratic::Symbol = :epsilon) where {T}
-        if !(quadratic in (:epsilon, :exact, :gehr, :cehr))
+        if !(quadratic in (:epsilon, :exact, :gehr, :cehr, :cehr_conic))
             error("Invalid `quadratic` option `:$(quadratic)`. Choose " *
-                  "from `:epsilon`, `:exact`, `:gehr`, or `:cehr`.")
+                  "from `:epsilon`, `:exact`, `:gehr`, `:cehr`, or " *
+                  "`:cehr_conic`.")
         end
         new{T}(ϵ, quadratic)
     end

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -409,28 +409,46 @@ end
 """
     Hull{T} <: AbstractReformulationMethod
 
-A type for using the convex hull reformulation approach for disjunctive 
+A type for using the convex hull reformulation approach for disjunctive
 constraints.
 
 **Fields**
 - `value::T`: epsilon value for nonlinear hull reformulations (default = `1e-6`).
+- `quadratic::Symbol`: reformulation used for quadratic disjunct
+  constraints (default = `:epsilon`). Options are:
+  - `:epsilon`: ε-approximated perspective (Furman, Sawaya & Grossmann
+    2020).
+  - `:exact`: exact hull (Gusev & Bernal Neira 2025); routes each
+    constraint to CEHR when its quadratic part is convex and to GEHR
+    otherwise (equality constraints always use GEHR since they are
+    nonconvex).
+  - `:gehr`: always use the General Exact Hull Reformulation.
+  - `:cehr`: always use the Conic Exact Hull Reformulation (errors on
+    nonconvex quadratic constraints).
 """
 struct Hull{T} <: AbstractReformulationMethod
     value::T
-    function Hull(ϵ::T = 1e-6) where {T}
-        new{T}(ϵ)
+    quadratic::Symbol
+    function Hull(ϵ::T = 1e-6; quadratic::Symbol = :epsilon) where {T}
+        if !(quadratic in (:epsilon, :exact, :gehr, :cehr))
+            error("Invalid `quadratic` option `:$(quadratic)`. Choose " *
+                  "from `:epsilon`, `:exact`, `:gehr`, or `:cehr`.")
+        end
+        new{T}(ϵ, quadratic)
     end
 end
 
 # temp struct to store variable disaggregations (reset for each disjunction)
 mutable struct _Hull{V <: JuMP.AbstractVariableRef, T} <: AbstractReformulationMethod
     value::T
+    quadratic::Symbol
     disjunction_variables::Dict{V, Vector{V}}
     disjunct_variables::Dict{Tuple{V, Union{V, JuMP.GenericAffExpr{T, V}}}, V}
     function _Hull(method::Hull{T}, vrefs::Set{V}) where {T, V <: JuMP.AbstractVariableRef}
         new{V, T}(
             method.value,
-            Dict{V, Vector{V}}(vref => V[] for vref in vrefs), 
+            method.quadratic,
+            Dict{V, Vector{V}}(vref => V[] for vref in vrefs),
             Dict{Tuple{V, Union{V, JuMP.GenericAffExpr{T, V}}}, V}()
         )
     end

--- a/src/hull.jl
+++ b/src/hull.jl
@@ -254,7 +254,8 @@ function reformulate_disjunction(model::JuMP.AbstractModel, disj::Disjunction, m
     return ref_cons
 end
 function reformulate_disjunction(model::JuMP.AbstractModel, disj::Disjunction, method::_Hull)
-    return reformulate_disjunction(model, disj, Hull(method.value))
+    hull = Hull(method.value; quadratic = method.quadratic)
+    return reformulate_disjunction(model, disj, hull)
 end
 
 function reformulate_disjunct_constraint(
@@ -348,8 +349,8 @@ function reformulate_disjunct_constraint(
     return [reform_con_gt, reform_con_lt]
 end
 function reformulate_disjunct_constraint(
-    model::JuMP.AbstractModel, 
-    con::JuMP.ScalarConstraint{T, S}, 
+    model::JuMP.AbstractModel,
+    con::JuMP.ScalarConstraint{T, S},
     bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::_Hull
 ) where {T <: JuMP.GenericNonlinearExpr, S <: _MOI.Interval}
@@ -365,4 +366,214 @@ function reformulate_disjunct_constraint(
     reform_con_gt = JuMP.build_constraint(error, new_func_gt, _MOI.GreaterThan(0))
     reform_con_lt = JuMP.build_constraint(error, new_func_lt, _MOI.LessThan(0))
     return [reform_con_gt, reform_con_lt]
+end
+
+################################################################################
+#                       EXACT QUADRATIC HULL (GEHR / CEHR)
+################################################################################
+# Exact hull reformulations for quadratic disjunct constraints
+# (Gusev & Bernal Neira 2025, arXiv:2508.16093), replacing the
+# ε-approximated perspective. Both are exact for the full relaxation
+# y ∈ [0, 1] given finite variable bounds (the disaggregated variable
+# bounds force ν = 0 when y = 0):
+# - GEHR (Eq. 13): multiply cl h̃(ν, y) ≤ 0 through by y to get
+#   ν'Qν + (a'ν)y + d*y² ≤ 0. Valid for any Q (nonconvex included)
+#   and for equalities, but the function is nonconvex in (ν, y).
+# - CEHR (Eq. 22): for convex constraints (Q ⪰ 0), epigraph variable
+#   t ≥ 0 with ν'Qν - t*y ≤ 0 and t + a'ν + d*y ≤ 0. The cone
+#   constraint is left unfactorized so conic-aware solvers recognize
+#   the rotated SOC in presolve; at y = 0 the link forces t = 0.
+
+# Assemble the symmetric coefficient matrix of the quadratic terms
+function _quad_coefficient_matrix(
+    quad::JuMP.GenericQuadExpr{C, V}
+    ) where {C, V}
+    index = Dict{V, Int}()
+    for (pair, _) in quad.terms
+        haskey(index, pair.a) || (index[pair.a] = length(index) + 1)
+        haskey(index, pair.b) || (index[pair.b] = length(index) + 1)
+    end
+    Q = zeros(float(C), length(index), length(index))
+    for (pair, coeff) in quad.terms
+        i, j = index[pair.a], index[pair.b]
+        if i == j
+            Q[i, i] += coeff
+        else
+            Q[i, j] += coeff / 2
+            Q[j, i] += coeff / 2
+        end
+    end
+    return Q
+end
+
+# Check whether the quadratic part is convex (Q ⪰ 0 up to a tolerance)
+function _is_convex_quad(quad::JuMP.GenericQuadExpr)
+    Q = _quad_coefficient_matrix(quad)
+    tol = 1e-9 * max(one(eltype(Q)), maximum(abs, Q))
+    return LinearAlgebra.eigmin(LinearAlgebra.Symmetric(Q)) >= -tol
+end
+
+# Disaggregate the quadratic terms without the ε-perspective division
+function _disaggregate_quad_terms(
+    model::JuMP.AbstractModel,
+    quad::JuMP.GenericQuadExpr,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::_Hull
+    )
+    new_expr = zero(typeof(quad))
+    for (pair, coeff) in quad.terms
+        da_ref = disaggregate_expression(model, pair.a, bvref, method)
+        db_ref = disaggregate_expression(model, pair.b, bvref, method)
+        JuMP.add_to_expression!(new_expr, coeff, da_ref, db_ref)
+    end
+    return new_expr
+end
+
+# GEHR expression (Eq. 13) for a constraint normalized to h(x) vs 0:
+# ν'Qν + (a'ν)*y + d*y²
+function _gehr_expression(
+    model::JuMP.AbstractModel,
+    h::JuMP.GenericQuadExpr,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::_Hull
+    )
+    aff_pers = disaggregate_expression(model, h.aff, bvref, method)
+    quad_part = _disaggregate_quad_terms(model, h, bvref, method)
+    return JuMP.@expression(model, quad_part + aff_pers*bvref)
+end
+
+# Add the CEHR epigraph variable t ≥ 0 for one quadratic constraint
+function _add_cehr_epigraph_variable(model::JuMP.AbstractModel, bvref)
+    base = "t_cehr_$(bvref)"
+    n = count(
+        v -> startswith(JuMP.name(v), base),
+        _reformulation_variables(model)
+    )
+    tvref = JuMP.@variable(model, lower_bound = 0,
+                           base_name = n == 0 ? base : "$(base)_$(n + 1)")
+    push!(_reformulation_variables(model), tvref)
+    return tvref
+end
+
+# Reformulate a quadratic constraint normalized to h(x) ≤ 0 exactly:
+# CEHR when the quadratic part is convex (unless `:gehr` is forced),
+# GEHR otherwise
+function _exact_quad_hull(
+    model::JuMP.AbstractModel,
+    h::JuMP.GenericQuadExpr,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::_Hull
+    )
+    if isempty(h.terms) # no quadratic terms: standard exact hull
+        aff_pers = disaggregate_expression(model, h.aff, bvref, method)
+        return [JuMP.build_constraint(error, aff_pers, _MOI.LessThan(0))]
+    elseif _is_convex_quad(h) && method.quadratic != :gehr
+        tvref = _add_cehr_epigraph_variable(model, bvref)
+        quad_part = _disaggregate_quad_terms(model, h, bvref, method)
+        aff_pers = disaggregate_expression(model, h.aff, bvref, method)
+        cone_func = JuMP.@expression(model, quad_part - tvref*bvref)
+        link_func = JuMP.@expression(model, tvref + aff_pers)
+        return [
+            JuMP.build_constraint(error, cone_func, _MOI.LessThan(0)),
+            JuMP.build_constraint(error, link_func, _MOI.LessThan(0))
+        ]
+    elseif method.quadratic == :cehr
+        error("`Hull(quadratic = :cehr)` requires convex quadratic " *
+              "disjunct constraints. Use `quadratic = :exact` or " *
+              "`quadratic = :gehr` for nonconvex quadratic constraints.")
+    else
+        gehr_func = _gehr_expression(model, h, bvref, method)
+        return [JuMP.build_constraint(error, gehr_func, _MOI.LessThan(0))]
+    end
+end
+
+# Reformulate a quadratic equality normalized to h(x) = 0 exactly
+# (GEHR; CEHR does not apply since quadratic equalities are nonconvex)
+function _exact_quad_hull_eq(
+    model::JuMP.AbstractModel,
+    h::JuMP.GenericQuadExpr,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::_Hull
+    )
+    if isempty(h.terms) # no quadratic terms: standard exact hull
+        aff_pers = disaggregate_expression(model, h.aff, bvref, method)
+        return [JuMP.build_constraint(error, aff_pers, _MOI.EqualTo(0))]
+    elseif method.quadratic == :cehr
+        error("`Hull(quadratic = :cehr)` does not support quadratic " *
+              "equality constraints. Use `quadratic = :exact` or " *
+              "`quadratic = :gehr` instead.")
+    end
+    gehr_func = _gehr_expression(model, h, bvref, method)
+    return [JuMP.build_constraint(error, gehr_func, _MOI.EqualTo(0))]
+end
+
+# scalar quadratic constraint
+function reformulate_disjunct_constraint(
+    model::JuMP.AbstractModel,
+    con::JuMP.ScalarConstraint{T, S},
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::_Hull
+) where {
+    T <: JuMP.GenericQuadExpr,
+    S <: Union{_MOI.LessThan, _MOI.GreaterThan, _MOI.EqualTo}
+}
+    set_value = _set_value(con.set)
+    if method.quadratic == :epsilon # ε-approximated perspective
+        new_func = disaggregate_expression(model, con.func, bvref, method)
+        new_func -= set_value*bvref
+        return [JuMP.build_constraint(error, new_func, S(0))]
+    elseif S <: _MOI.EqualTo
+        return _exact_quad_hull_eq(model, con.func - set_value, bvref, method)
+    else # normalize to h(x) ≤ 0 (flip GreaterThan constraints)
+        h = S <: _MOI.LessThan ? con.func - set_value : set_value - con.func
+        return _exact_quad_hull(model, h, bvref, method)
+    end
+end
+# scalar quadratic constraint in an interval
+function reformulate_disjunct_constraint(
+    model::JuMP.AbstractModel,
+    con::JuMP.ScalarConstraint{T, S},
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::_Hull
+) where {T <: JuMP.GenericQuadExpr, S <: _MOI.Interval}
+    if method.quadratic == :epsilon # ε-approximated perspective
+        new_func = disaggregate_expression(model, con.func, bvref, method)
+        new_func_gt = JuMP.@expression(model, new_func - con.set.lower*bvref)
+        new_func_lt = JuMP.@expression(model, new_func - con.set.upper*bvref)
+        return [
+            JuMP.build_constraint(error, new_func_gt, _MOI.GreaterThan(0)),
+            JuMP.build_constraint(error, new_func_lt, _MOI.LessThan(0))
+        ]
+    end
+    return vcat(
+        _exact_quad_hull(model, con.func - con.set.upper, bvref, method),
+        _exact_quad_hull(model, con.set.lower - con.func, bvref, method)
+    )
+end
+# vector quadratic constraint
+function reformulate_disjunct_constraint(
+    model::JuMP.AbstractModel,
+    con::JuMP.VectorConstraint{T, S, R},
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::_Hull
+) where {
+    T <: JuMP.GenericQuadExpr,
+    S <: Union{_MOI.Nonpositives, _MOI.Nonnegatives, _MOI.Zeros}, R
+}
+    if method.quadratic == :epsilon # ε-approximated perspective
+        new_func = JuMP.@expression(model, [i=1:con.set.dimension],
+            disaggregate_expression(model, con.func[i], bvref, method)
+        )
+        return [JuMP.build_constraint(error, new_func, con.set)]
+    end
+    reform_cons = Vector{AbstractConstraint}()
+    for func in con.func # normalize each entry to h(x) ≤ 0 or h(x) = 0
+        h = S <: _MOI.Nonnegatives ? -func : func
+        if S <: _MOI.Zeros
+            append!(reform_cons, _exact_quad_hull_eq(model, h, bvref, method))
+        else
+            append!(reform_cons, _exact_quad_hull(model, h, bvref, method))
+        end
+    end
+    return reform_cons
 end

--- a/src/hull.jl
+++ b/src/hull.jl
@@ -281,6 +281,24 @@ function reformulate_disjunct_constraint(
     reform_con = JuMP.build_constraint(error, new_func, con.set)
     return [reform_con]
 end
+
+function reformulate_disjunct_constraint(
+    model::JuMP.AbstractModel,
+    con::JuMP.VectorConstraint{T, S, R},
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::_Hull
+) where {
+    T <: Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    S <: Union{_MOI.SecondOrderCone, _MOI.RotatedSecondOrderCone,
+        _MOI.ExponentialCone, _MOI.PowerCone},
+    R
+}
+    new_func = JuMP.@expression(model, [i=1:_MOI.dimension(con.set)],
+        disaggregate_expression(model, con.func[i], bvref, method)
+    )
+    reform_con = JuMP.build_constraint(error, new_func, con.set)
+    return [reform_con]
+end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel, 
     con::JuMP.ScalarConstraint{T, S}, 

--- a/src/hull.jl
+++ b/src/hull.jl
@@ -289,9 +289,7 @@ function reformulate_disjunct_constraint(
     method::_Hull
 ) where {
     T <: Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
-    S <: Union{_MOI.SecondOrderCone, _MOI.RotatedSecondOrderCone,
-        _MOI.ExponentialCone, _MOI.PowerCone},
-    R
+    S <: _ConicSets, R
 }
     new_func = JuMP.@expression(model, [i=1:_MOI.dimension(con.set)],
         disaggregate_expression(model, con.func[i], bvref, method)

--- a/src/hull.jl
+++ b/src/hull.jl
@@ -384,16 +384,17 @@ end
 #   constraint is left unfactorized so conic-aware solvers recognize
 #   the rotated SOC in presolve; at y = 0 the link forces t = 0.
 
-# Assemble the symmetric coefficient matrix of the quadratic terms
+# Assemble the symmetric coefficient matrix of the quadratic terms and
+# the variables indexing its rows, in order of first appearance
 function _quad_coefficient_matrix(
     quad::JuMP.GenericQuadExpr{C, V}
     ) where {C, V}
     index = Dict{V, Int}()
-    for (pair, _) in quad.terms
-        haskey(index, pair.a) || (index[pair.a] = length(index) + 1)
-        haskey(index, pair.b) || (index[pair.b] = length(index) + 1)
+    vars = V[]
+    for (pair, _) in quad.terms, v in (pair.a, pair.b)
+        haskey(index, v) || (push!(vars, v); index[v] = length(vars))
     end
-    Q = zeros(float(C), length(index), length(index))
+    Q = zeros(float(C), length(vars), length(vars))
     for (pair, coeff) in quad.terms
         i, j = index[pair.a], index[pair.b]
         if i == j
@@ -403,12 +404,12 @@ function _quad_coefficient_matrix(
             Q[j, i] += coeff / 2
         end
     end
-    return Q
+    return Q, vars
 end
 
 # Check whether the quadratic part is convex (Q ⪰ 0 up to a tolerance)
 function _is_convex_quad(quad::JuMP.GenericQuadExpr)
-    Q = _quad_coefficient_matrix(quad)
+    Q, _ = _quad_coefficient_matrix(quad)
     tol = 1e-9 * max(one(eltype(Q)), maximum(abs, Q))
     return LinearAlgebra.eigmin(LinearAlgebra.Symmetric(Q)) >= -tol
 end
@@ -455,9 +456,38 @@ function _add_cehr_epigraph_variable(model::JuMP.AbstractModel, bvref)
     return tvref
 end
 
+# CEHR for solvers that accept cones: the quadratic is handed over as
+# an explicit rotated second-order cone
+function _cehr_conic_constraints(
+    model::JuMP.AbstractModel,
+    h::JuMP.GenericQuadExpr,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
+    method::_Hull
+    )
+    tvref = _add_cehr_epigraph_variable(model, bvref)
+    Q, vars = _quad_coefficient_matrix(h)
+    factors = LinearAlgebra.eigen(LinearAlgebra.Symmetric(Q))
+    tol = 1e-9 * max(one(eltype(Q)), maximum(abs, Q))
+    dvars = [disaggregate_expression(model, v, bvref, method)
+             for v in vars]
+    rows = [0.5 * tvref, zero(0.5 * tvref) + bvref]
+    for k in findall(>(tol), factors.values) # drop zero eigenvalues
+        push!(rows, sqrt(factors.values[k]) * sum(
+            factors.vectors[j, k] * dvars[j] for j in eachindex(dvars)))
+    end
+    aff_pers = disaggregate_expression(model, h.aff, bvref, method)
+    link_func = JuMP.@expression(model, tvref + aff_pers)
+    return [
+        JuMP.build_constraint(error, rows,
+            _MOI.RotatedSecondOrderCone(length(rows))),
+        JuMP.build_constraint(error, link_func, _MOI.LessThan(0))
+    ]
+end
+
 # Reformulate a quadratic constraint normalized to h(x) ≤ 0 exactly:
 # CEHR when the quadratic part is convex (unless `:gehr` is forced),
-# GEHR otherwise
+# GEHR otherwise. CEHR stays algebraic for solvers that do not accept
+# cones; `:cehr_conic` writes the cone out for solvers that do.
 function _exact_quad_hull(
     model::JuMP.AbstractModel,
     h::JuMP.GenericQuadExpr,
@@ -467,6 +497,8 @@ function _exact_quad_hull(
     if isempty(h.terms) # no quadratic terms: standard exact hull
         aff_pers = disaggregate_expression(model, h.aff, bvref, method)
         return [JuMP.build_constraint(error, aff_pers, _MOI.LessThan(0))]
+    elseif _is_convex_quad(h) && method.quadratic == :cehr_conic
+        return _cehr_conic_constraints(model, h, bvref, method)
     elseif _is_convex_quad(h) && method.quadratic != :gehr
         tvref = _add_cehr_epigraph_variable(model, bvref)
         quad_part = _disaggregate_quad_terms(model, h, bvref, method)
@@ -477,10 +509,10 @@ function _exact_quad_hull(
             JuMP.build_constraint(error, cone_func, _MOI.LessThan(0)),
             JuMP.build_constraint(error, link_func, _MOI.LessThan(0))
         ]
-    elseif method.quadratic == :cehr
-        error("`Hull(quadratic = :cehr)` requires convex quadratic " *
-              "disjunct constraints. Use `quadratic = :exact` or " *
-              "`quadratic = :gehr` for nonconvex quadratic constraints.")
+    elseif method.quadratic in (:cehr, :cehr_conic)
+        error("`Hull(quadratic = :$(method.quadratic))` requires convex " *
+              "quadratic disjunct constraints. Use `quadratic = :exact` " *
+              "or `quadratic = :gehr` for nonconvex quadratic constraints.")
     else
         gehr_func = _gehr_expression(model, h, bvref, method)
         return [JuMP.build_constraint(error, gehr_func, _MOI.LessThan(0))]
@@ -498,10 +530,10 @@ function _exact_quad_hull_eq(
     if isempty(h.terms) # no quadratic terms: standard exact hull
         aff_pers = disaggregate_expression(model, h.aff, bvref, method)
         return [JuMP.build_constraint(error, aff_pers, _MOI.EqualTo(0))]
-    elseif method.quadratic == :cehr
-        error("`Hull(quadratic = :cehr)` does not support quadratic " *
-              "equality constraints. Use `quadratic = :exact` or " *
-              "`quadratic = :gehr` instead.")
+    elseif method.quadratic in (:cehr, :cehr_conic)
+        error("`Hull(quadratic = :$(method.quadratic))` does not support " *
+              "quadratic equality constraints. Use `quadratic = :exact` " *
+              "or `quadratic = :gehr` instead.")
     end
     gehr_func = _gehr_expression(model, h, bvref, method)
     return [JuMP.build_constraint(error, gehr_func, _MOI.EqualTo(0))]

--- a/test/constraints/bigm.jl
+++ b/test/constraints/bigm.jl
@@ -374,16 +374,6 @@ function test_power_bigm()
     @test ref[1].set == MOI.PowerCone(0.5)
 end
 
-function test_conic_bigm_inf_error()
-    model = GDPModel()
-    @variable(model, x)
-    @variable(model, t)
-    @variable(model, y, Logical)
-    @constraint(model, con, [t, x] in SecondOrderCone(), Disjunct(y))
-    bvref = binary_variable(y)
-    @test_throws ErrorException reformulate_disjunct_constraint(model, constraint_object(con), bvref, BigM(Inf, false))
-end
-
 @testset "BigM Reformulation" begin
     test_default_bigm()
     test_default_tighten_bigm()
@@ -408,5 +398,4 @@ end
     test_rsoc_bigm()
     test_exp_bigm()
     test_power_bigm()
-    test_conic_bigm_inf_error()
 end

--- a/test/constraints/bigm.jl
+++ b/test/constraints/bigm.jl
@@ -313,6 +313,77 @@ function test_extension_bigm()
     @test refcons[4].set == MOI.GreaterThan(10.0 - 110)
 end
 
+function test_soc_bigm()
+    model = GDPModel()
+    @variable(model, x)
+    @variable(model, t)
+    @variable(model, y, Logical)
+    @constraint(model, con, [t, x] in SecondOrderCone(), Disjunct(y))
+    bvref = binary_variable(y)
+    ref = reformulate_disjunct_constraint(model, constraint_object(con), bvref, BigM(100, false))
+    @test length(ref) == 1
+    @test isequal_canonical(ref[1].func[1], t + 100*(1 - bvref))
+    @test isequal_canonical(ref[1].func[2], 1.0*x)
+    @test ref[1].set == MOI.SecondOrderCone(2)
+end
+
+function test_rsoc_bigm()
+    model = GDPModel()
+    @variable(model, x)
+    @variable(model, t)
+    @variable(model, y, Logical)
+    @constraint(model, con, [0.5, t, x] in RotatedSecondOrderCone(), Disjunct(y))
+    bvref = binary_variable(y)
+    ref = reformulate_disjunct_constraint(model, constraint_object(con), bvref, BigM(100, false))
+    @test length(ref) == 1
+    @test isequal_canonical(ref[1].func[1], 0.5 + 100*(1 - bvref))
+    @test isequal_canonical(ref[1].func[2], t + 100*(1 - bvref))
+    @test isequal_canonical(ref[1].func[3], 1.0*x)
+    @test ref[1].set == MOI.RotatedSecondOrderCone(3)
+end
+
+function test_exp_bigm()
+    model = GDPModel()
+    @variable(model, x)
+    @variable(model, t)
+    @variable(model, w)
+    @variable(model, y, Logical)
+    @constraint(model, con, [x, t, w] in MOI.ExponentialCone(), Disjunct(y))
+    bvref = binary_variable(y)
+    ref = reformulate_disjunct_constraint(model, constraint_object(con), bvref, BigM(100, false))
+    @test length(ref) == 1
+    @test isequal_canonical(ref[1].func[1], 1.0*x)
+    @test isequal_canonical(ref[1].func[2], t + 100*(1 - bvref))
+    @test isequal_canonical(ref[1].func[3], w + 200*(1 - bvref))
+    @test ref[1].set == MOI.ExponentialCone()
+end
+
+function test_power_bigm()
+    model = GDPModel()
+    @variable(model, x)
+    @variable(model, t)
+    @variable(model, w)
+    @variable(model, y, Logical)
+    @constraint(model, con, [x, t, w] in MOI.PowerCone(0.5), Disjunct(y))
+    bvref = binary_variable(y)
+    ref = reformulate_disjunct_constraint(model, constraint_object(con), bvref, BigM(100, false))
+    @test length(ref) == 1
+    @test isequal_canonical(ref[1].func[1], x + 100*(1 - bvref))
+    @test isequal_canonical(ref[1].func[2], t + 100*(1 - bvref))
+    @test isequal_canonical(ref[1].func[3], 1.0*w)
+    @test ref[1].set == MOI.PowerCone(0.5)
+end
+
+function test_conic_bigm_inf_error()
+    model = GDPModel()
+    @variable(model, x)
+    @variable(model, t)
+    @variable(model, y, Logical)
+    @constraint(model, con, [t, x] in SecondOrderCone(), Disjunct(y))
+    bvref = binary_variable(y)
+    @test_throws ErrorException reformulate_disjunct_constraint(model, constraint_object(con), bvref, BigM(Inf, false))
+end
+
 @testset "BigM Reformulation" begin
     test_default_bigm()
     test_default_tighten_bigm()
@@ -333,4 +404,9 @@ end
     test_zeros_bigm()
     test_nested_bigm()
     test_extension_bigm()
+    test_soc_bigm()
+    test_rsoc_bigm()
+    test_exp_bigm()
+    test_power_bigm()
+    test_conic_bigm_inf_error()
 end

--- a/test/constraints/hull.jl
+++ b/test/constraints/hull.jl
@@ -662,6 +662,62 @@ function test_extension_hull()
     # TODO add more tests
 end
 
+function test_vector_soc_hull()
+    model = GDPModel()
+    @variable(model, 10 <= x <= 100)
+    @variable(model, 10 <= t <= 100)
+    @variable(model, z, Logical)
+    @constraint(model, con, [t - 5, x - 5] in SecondOrderCone(), Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(1e-3), Set([x, t]))
+    prep_bounds([x, t], model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x, t]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    t_z = variable_by_name(model, "t_z")
+    ref = reformulate_disjunct_constraint(model, constraint_object(con), zbin, method)
+    @test length(ref) == 1
+    @test ref[1].func == [t_z - 5*zbin, x_z - 5*zbin]
+    @test ref[1].set == MOI.SecondOrderCone(2)
+end
+
+function test_vector_rsoc_hull()
+    model = GDPModel()
+    @variable(model, 10 <= x <= 100)
+    @variable(model, 10 <= t <= 100)
+    @variable(model, z, Logical)
+    @constraint(model, con, [0.5, t - 2, x - 3] in RotatedSecondOrderCone(), Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(1e-3), Set([x, t]))
+    prep_bounds([x, t], model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x, t]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    t_z = variable_by_name(model, "t_z")
+    ref = reformulate_disjunct_constraint(model, constraint_object(con), zbin, method)
+    @test length(ref) == 1
+    @test ref[1].func == [0.5*zbin, t_z - 2*zbin, x_z - 3*zbin]
+    @test ref[1].set == MOI.RotatedSecondOrderCone(3)
+end
+
+function test_vector_exp_hull()
+    model = GDPModel()
+    @variable(model, 10 <= x <= 100)
+    @variable(model, 10 <= t <= 100)
+    @variable(model, 10 <= w <= 100)
+    @variable(model, z, Logical)
+    @constraint(model, con, [x - 1, t - 1, w - 1] in MOI.ExponentialCone(), Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(1e-3), Set([x, t, w]))
+    prep_bounds([x, t, w], model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x, t, w]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    t_z = variable_by_name(model, "t_z")
+    w_z = variable_by_name(model, "w_z")
+    ref = reformulate_disjunct_constraint(model, constraint_object(con), zbin, method)
+    @test length(ref) == 1
+    @test ref[1].func == [x_z - zbin, t_z - zbin, w_z - zbin]
+    @test ref[1].set == MOI.ExponentialCone()
+end
+
 @testset "Hull Reformulation" begin
     test_default_hull()
     test_set_hull()
@@ -703,4 +759,7 @@ end
     test_scalar_nonlinear_hull_2sided_error()
     test_exactly1_error()
     test_extension_hull()
+    test_vector_soc_hull()
+    test_vector_rsoc_hull()
+    test_vector_exp_hull()
 end

--- a/test/constraints/hull.jl
+++ b/test/constraints/hull.jl
@@ -777,6 +777,68 @@ function test_scalar_cehr_hull_concave_greater()
     @test isequal_canonical(ref[1].func, x_z^2 - t*zbin)
     @test isequal_canonical(ref[2].func, t - 3*x_z + 1*zbin)
 end
+#cehr_conic writes the cone out as an explicit rotated SOC
+function test_scalar_cehr_conic_hull()
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, x^2 + 3x <= 5, Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :cehr_conic), Set([x]))
+    prep_bounds(x, model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    ref = reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    @test length(ref) == 2
+    t = variable_by_name(model, "t_cehr_z")
+    @test lower_bound(t) == 0
+    @test ref[1].set == MOI.RotatedSecondOrderCone(3)
+    @test isequal_canonical(ref[1].func[1], 0.5 * t)
+    @test isequal_canonical(ref[1].func[2], 1.0 * zbin)
+    # eigenvector sign is implementation-defined
+    @test abs(coefficient(ref[1].func[3], x_z)) ≈ 1.0
+    @test isequal_canonical(ref[2].func, t + 3*x_z - 5*zbin)
+    @test ref[2].set == MOI.LessThan(0.0)
+end
+#singular Q drops its zero eigenvalue rows from the cone
+function test_scalar_cehr_conic_rank_deficient()
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, -2 <= w <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, (x + w)^2 <= 4, Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :cehr_conic), Set([x, w]))
+    prep_bounds([x, w], model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x, w]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    w_z = variable_by_name(model, "w_z")
+    ref = reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    @test ref[1].set == MOI.RotatedSecondOrderCone(3) # rank 1, not 2
+    row = ref[1].func[3]
+    s = sign(coefficient(row, x_z))
+    @test coefficient(row, x_z) ≈ s * 1.0
+    @test coefficient(row, w_z) ≈ s * 1.0
+end
+#cehr_conic rejects nonconvex and equality constraints like cehr
+function test_scalar_cehr_conic_errors()
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, -2 <= w <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, x*w <= 5, Disjunct(z))
+    @constraint(model, con_eq, x^2 == 4, Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :cehr_conic), Set([x, w]))
+    prep_bounds([x, w], model, Hull())
+    DP._disaggregate_variables(model, z, Set([x, w]), method)
+    @test_throws ErrorException reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    @test_throws ErrorException reformulate_disjunct_constraint(
+        model, constraint_object(con_eq), zbin, method)
+end
 #nonconvex quadratic routed to GEHR under :exact, error under :cehr
 function test_scalar_exact_hull_nonconvex()
     model = GDPModel()
@@ -944,6 +1006,9 @@ end
     test_hull_quadratic_option_error()
     test_scalar_cehr_hull()
     test_scalar_cehr_hull_concave_greater()
+    test_scalar_cehr_conic_hull()
+    test_scalar_cehr_conic_rank_deficient()
+    test_scalar_cehr_conic_errors()
     test_scalar_exact_hull_nonconvex()
     test_scalar_exact_hull_equality()
     test_scalar_exact_hull_2sided()

--- a/test/constraints/hull.jl
+++ b/test/constraints/hull.jl
@@ -718,6 +718,198 @@ function test_vector_exp_hull()
     @test ref[1].set == MOI.ExponentialCone()
 end
 
+function test_hull_quadratic_option_error()
+    @test_throws ErrorException Hull(quadratic = :bad_option)
+    @test Hull().quadratic == :epsilon
+    @test Hull(1e-3, quadratic = :exact).quadratic == :exact
+end
+#less than, greater than, equalto with GEHR forced
+function test_scalar_gehr_hull_1sided(moiset)
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, x^2 + 3x in moiset(5), Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :gehr), Set([x]))
+    prep_bounds(x, model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    ref = reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    @test length(ref) == 1
+    gehr = x_z^2 + 3*x_z*zbin - 5*zbin^2
+    if moiset == MOI.GreaterThan # flipped to h(x) ≤ 0
+        @test isequal_canonical(ref[1].func, -gehr)
+        @test ref[1].set == MOI.LessThan(0.0)
+    else
+        @test isequal_canonical(ref[1].func, gehr)
+        expected = moiset == MOI.EqualTo ? MOI.EqualTo(0.0) :
+            MOI.LessThan(0.0)
+        @test ref[1].set == expected
+    end
+end
+#convex quadratic routed to CEHR under :exact
+function test_scalar_cehr_hull()
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, x^2 + 3x <= 5, Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :exact), Set([x]))
+    prep_bounds(x, model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    ref = reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    @test length(ref) == 2
+    t = variable_by_name(model, "t_cehr_z")
+    @test lower_bound(t) == 0
+    @test isequal_canonical(ref[1].func, x_z^2 - t*zbin)
+    @test ref[1].set == MOI.LessThan(0.0)
+    @test isequal_canonical(ref[2].func, t + 3*x_z - 5*zbin)
+    @test ref[2].set == MOI.LessThan(0.0)
+end
+#concave greater-than flips to a convex constraint and routes to CEHR
+function test_scalar_cehr_hull_concave_greater()
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, -x^2 + 3x >= 1, Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :exact), Set([x]))
+    prep_bounds(x, model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    ref = reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    @test length(ref) == 2
+    t = variable_by_name(model, "t_cehr_z")
+    @test isequal_canonical(ref[1].func, x_z^2 - t*zbin)
+    @test isequal_canonical(ref[2].func, t - 3*x_z + 1*zbin)
+end
+#nonconvex quadratic routed to GEHR under :exact, error under :cehr
+function test_scalar_exact_hull_nonconvex()
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, -2 <= w <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, x*w <= 5, Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :exact), Set([x, w]))
+    prep_bounds([x, w], model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x, w]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    w_z = variable_by_name(model, "w_z")
+    ref = reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    @test length(ref) == 1
+    @test isequal_canonical(ref[1].func, x_z*w_z - 5*zbin^2)
+    @test ref[1].set == MOI.LessThan(0.0)
+    forced = DP._Hull(Hull(quadratic = :cehr), Set([x, w]))
+    forced.disjunct_variables = method.disjunct_variables
+    @test_throws ErrorException reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, forced)
+end
+#quadratic equality reformulated by GEHR, error under :cehr
+function test_scalar_exact_hull_equality()
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, x^2 == 5, Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :exact), Set([x]))
+    prep_bounds(x, model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    ref = reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    @test length(ref) == 1
+    @test isequal_canonical(ref[1].func, x_z^2 - 5*zbin^2)
+    @test ref[1].set == MOI.EqualTo(0.0)
+    forced = DP._Hull(Hull(quadratic = :cehr), Set([x]))
+    forced.disjunct_variables = method.disjunct_variables
+    @test_throws ErrorException reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, forced)
+end
+#interval: CEHR on the upper side, GEHR on the (nonconvex) lower side
+function test_scalar_exact_hull_2sided()
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, 2 <= x^2 <= 5, Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :exact), Set([x]))
+    prep_bounds(x, model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    ref = reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    @test length(ref) == 3
+    t = variable_by_name(model, "t_cehr_z")
+    @test isequal_canonical(ref[1].func, x_z^2 - t*zbin)
+    @test ref[1].set == MOI.LessThan(0.0)
+    @test isequal_canonical(ref[2].func, t - 5*zbin)
+    @test ref[2].set == MOI.LessThan(0.0)
+    @test isequal_canonical(ref[3].func, -x_z^2 + 2*zbin^2)
+    @test ref[3].set == MOI.LessThan(0.0)
+end
+#nonpositives, nonnegatives, zeros with exact reformulations
+function test_vector_exact_hull_1sided(moiset)
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, z, Logical)
+    @constraint(model, con, [x^2 - 5; x^2 - 5] in moiset(2), Disjunct(z))
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :exact), Set([x]))
+    prep_bounds(x, model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    ref = reformulate_disjunct_constraint(
+        model, constraint_object(con), zbin, method)
+    if moiset == MOI.Nonpositives # convex entries: CEHR per entry
+        @test length(ref) == 4
+        @test all(r.set == MOI.LessThan(0.0) for r in ref)
+        tvars = filter(v -> startswith(name(v), "t_cehr"), all_variables(model))
+        @test length(tvars) == 2
+        @test all(lower_bound(t) == 0 for t in tvars)
+    elseif moiset == MOI.Nonnegatives # flipped: nonconvex, GEHR
+        @test length(ref) == 2
+        for i in 1:2
+            @test isequal_canonical(ref[i].func, -x_z^2 + 5*zbin^2)
+            @test ref[i].set == MOI.LessThan(0.0)
+        end
+    else # Zeros: equalities, GEHR
+        @test length(ref) == 2
+        for i in 1:2
+            @test isequal_canonical(ref[i].func, x_z^2 - 5*zbin^2)
+            @test ref[i].set == MOI.EqualTo(0.0)
+        end
+    end
+end
+#quadratic expression without quadratic terms falls back to affine hull
+function test_exact_hull_affine_fallback()
+    model = GDPModel()
+    @variable(model, -2 <= x <= 3)
+    @variable(model, z, Logical)
+    zbin = variable_by_name(model, "z")
+    method = DP._Hull(Hull(quadratic = :exact), Set([x]))
+    prep_bounds(x, model, Hull())
+    @test DP._disaggregate_variables(model, z, Set([x]), method) isa Nothing
+    x_z = variable_by_name(model, "x_z")
+    con = JuMP.build_constraint(
+        error, convert(QuadExpr, 2.0x + 1.0), MOI.LessThan(5.0))
+    ref = reformulate_disjunct_constraint(model, con, zbin, method)
+    @test length(ref) == 1
+    @test isequal_canonical(ref[1].func, 2*x_z + 1*zbin - 5*zbin)
+    @test ref[1].set == MOI.LessThan(0.0)
+    con = JuMP.build_constraint(
+        error, convert(QuadExpr, 2.0x + 1.0), MOI.EqualTo(5.0))
+    ref = reformulate_disjunct_constraint(model, con, zbin, method)
+    @test length(ref) == 1
+    @test isequal_canonical(ref[1].func, 2*x_z + 1*zbin - 5*zbin)
+    @test ref[1].set == MOI.EqualTo(0.0)
+end
+
 @testset "Hull Reformulation" begin
     test_default_hull()
     test_set_hull()
@@ -741,14 +933,16 @@ end
     for s in (MOI.LessThan, MOI.GreaterThan, MOI.EqualTo)
         test_scalar_var_hull_1sided(s)
         test_scalar_affine_hull_1sided(s)
-        test_scalar_quadratic_hull_1sided(s)        
+        test_scalar_quadratic_hull_1sided(s)
+        test_scalar_gehr_hull_1sided(s)
         test_scalar_nonlinear_hull_1sided(s)
     end
     test_scalar_nonlinear_hull_1sided_error()
     for s in (MOI.Nonpositives, MOI.Nonnegatives, MOI.Zeros)
         test_vector_var_hull_1sided(s)
         test_vector_affine_hull_1sided(s)
-        test_vector_quadratic_hull_1sided(s)        
+        test_vector_quadratic_hull_1sided(s)
+        test_vector_exact_hull_1sided(s)
         test_vector_nonlinear_hull_1sided(s)
     end
     test_vector_nonlinear_hull_1sided_error()
@@ -757,6 +951,13 @@ end
     test_scalar_quadratic_hull_2sided()
     test_scalar_nonlinear_hull_2sided()
     test_scalar_nonlinear_hull_2sided_error()
+    test_hull_quadratic_option_error()
+    test_scalar_cehr_hull()
+    test_scalar_cehr_hull_concave_greater()
+    test_scalar_exact_hull_nonconvex()
+    test_scalar_exact_hull_equality()
+    test_scalar_exact_hull_2sided()
+    test_exact_hull_affine_fallback()
     test_exactly1_error()
     test_extension_hull()
     test_vector_soc_hull()

--- a/test/extensions/InfiniteDisjunctiveProgramming.jl
+++ b/test/extensions/InfiniteDisjunctiveProgramming.jl
@@ -121,6 +121,37 @@ function test_requires_disaggregation()
     @test DP.requires_disaggregation(y) == true
 end
 
+# Bound info for parameter refs in disjunct constraints: parameter
+# functions report their support extrema, finite parameters a point,
+# other parameters their domain bounds; Hull/PSplit clamp the bounds
+# to include 0 and error when a variable is missing bounds.
+function test_parameter_bound_info()
+    model = InfiniteGDPModel()
+    @infinite_parameter(model, t in [0, 1], supports = [0.0, 0.5, 1.0])
+    @infinite_parameter(model, s in [0, 1])
+    @finite_parameter(model, p == 2.0)
+    @variable(model, 0 <= x <= 10, Infinite(t))
+    @variable(model, y, Infinite(t))
+    @parameter_function(model, pf == t -> 2t - 1)
+    @parameter_function(model, pf2 == (t, s) -> t + s)
+    @parameter_function(model, pf3 == s -> s)
+    @test DP.set_variable_bound_info(pf, BigM()) == (-1.0, 1.0)
+    @test DP.set_variable_bound_info(p, BigM()) == (2.0, 2.0)
+    @test DP.set_variable_bound_info(t, BigM()) == (0.0, 1.0)
+    @test DP.set_variable_bound_info(x, BigM()) == (0.0, 10.0)
+    @test DP.set_variable_bound_info(y, BigM()) == (-Inf, Inf)
+    # multi-parameter and support-less parameter functions fall back
+    @test DP.set_variable_bound_info(pf2, BigM()) == (-Inf, Inf)
+    @test DP.set_variable_bound_info(pf3, BigM()) == (-Inf, Inf)
+    # Hull and PSplit clamp the bounds to include 0
+    @test DP.set_variable_bound_info(pf, Hull()) == (-1.0, 1.0)
+    @test DP.set_variable_bound_info(t, Hull()) == (0.0, 1.0)
+    @test DP.set_variable_bound_info(p, Hull()) == (0.0, 2.0)
+    @test DP.set_variable_bound_info(x, Hull()) == (0.0, 10.0)
+    @test DP.set_variable_bound_info(p, PSplit([[x]])) == (0.0, 2.0)
+    @test_throws ErrorException DP.set_variable_bound_info(y, Hull())
+end
+
 function test_all_variables_infiniteopt()
     model = InfiniteGDPModel()
     @infinite_parameter(model, t ∈ [0, 1])
@@ -806,6 +837,7 @@ end
         test_is_parameter()
         test_is_parameter_concrete_dispatches()
         test_requires_disaggregation()
+        test_parameter_bound_info()
         test_variable_properties_infiniteopt()
         test_variable_properties_from_expr()
         test_variable_properties_from_quad_expr()

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -233,6 +233,31 @@ function test_exact_quadratic_gdp_example()
     end
 end
 
+function test_cehr_conic_gdp_example()
+    # Same disks as above, but reformulated to explicit rotated SOCs
+    # (quadratic = :cehr_conic) and solved as a true MICP.
+    oa = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
+    cs = optimizer_with_attributes(Hypatia.Optimizer, MOI.Silent() => true)
+    paj = optimizer_with_attributes(Pajarito.Optimizer,
+        "oa_solver" => oa, "conic_solver" => cs, "verbose" => false)
+    m = GDPModel(paj)
+    set_attribute(m, MOI.Silent(), true)
+    @variable(m, -10 <= x <= 10)
+    @variable(m, -10 <= y <= 10)
+    @variable(m, Y[1:2], Logical)
+    @objective(m, Min, x)
+    @constraint(m, x^2 + y^2 <= 1, Disjunct(Y[1]))
+    @constraint(m, (x - 5)^2 + y^2 <= 1, Disjunct(Y[2]))
+    @disjunction(m, Y)
+    @test optimize!(m, gdp_method = Hull(quadratic = :cehr_conic)) isa Nothing
+    @test termination_status(m) == MOI.OPTIMAL
+    @test isapprox(objective_value(m), -1, atol = 1e-4)
+    @test isapprox(value(x), -1, atol = 1e-4)
+    @test value(Y[1])
+    @test !value(Y[2])
+end
+
 @testset "Solve Exact Quadratic GDP" begin
     test_exact_quadratic_gdp_example()
+    test_cehr_conic_gdp_example()
 end

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -202,3 +202,37 @@ end
 @testset "Solve Conic GDP" begin
     test_conic_gdp_example()
 end
+
+function test_exact_quadratic_gdp_example()
+    # Quadratic version of the circle disjunction above: the point must
+    # lie in the unit disk around (0, 0) or around (5, 0); minimizing x
+    # selects the first disk at (x, y) = (-1, 0). The exact hull
+    # reformulations (CEHR/GEHR, Gusev & Bernal Neira 2025) must agree
+    # with BigM and the ε-approximated hull.
+    ipopt = optimizer_with_attributes(Ipopt.Optimizer,
+        "print_level" => 0, "sb" => "yes")
+    juniper = optimizer_with_attributes(Juniper.Optimizer,
+        "nl_solver" => ipopt)
+    for meth in (BigM(100), Hull(), Hull(quadratic = :exact),
+                 Hull(quadratic = :gehr))
+        m = GDPModel(juniper)
+        set_attribute(m, MOI.Silent(), true)
+        @variable(m, -10 <= x <= 10)
+        @variable(m, -10 <= y <= 10)
+        @variable(m, Y[1:2], Logical)
+        @objective(m, Min, x)
+        @constraint(m, x^2 + y^2 <= 1, Disjunct(Y[1]))
+        @constraint(m, (x - 5)^2 + y^2 <= 1, Disjunct(Y[2]))
+        @disjunction(m, Y)
+        @test optimize!(m, gdp_method = meth) isa Nothing
+        @test termination_status(m) in (MOI.OPTIMAL, MOI.LOCALLY_SOLVED)
+        @test isapprox(objective_value(m), -1, atol = 1e-4)
+        @test isapprox(value(x), -1, atol = 1e-4)
+        @test value(Y[1])
+        @test !value(Y[2])
+    end
+end
+
+@testset "Solve Exact Quadratic GDP" begin
+    test_exact_quadratic_gdp_example()
+end

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -1,4 +1,4 @@
-using HiGHS, Ipopt, Juniper
+using HiGHS, Ipopt, Juniper, Pajarito, Hypatia
 function test_linear_gdp_example(m, use_complements = false)
     set_attribute(m, MOI.Silent(), true)
     @variable(m, 1 ≤ x[1:2] ≤ 9)
@@ -167,4 +167,38 @@ end
         )
     test_quadratic_gdp_example()
     test_generic_model(GDPModel{Float32}(mockoptimizer))
+end
+
+function test_conic_gdp_example()
+    # Circle-containment idea from Bernal Neira & Grossmann (2021),
+    # Eq. 4.3: the point (x, y) must lie in the unit circle around
+    # (0, 0) OR around (5, 0), expressed as second-order cones. The
+    # disjunction picks one circle; minimizing x selects the first and
+    # lands on its leftmost point, (x, y) = (-1, 0).
+    oa = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
+    cs = optimizer_with_attributes(Hypatia.Optimizer, MOI.Silent() => true)
+    paj = optimizer_with_attributes(Pajarito.Optimizer,
+        "oa_solver" => oa, "conic_solver" => cs, "verbose" => false)
+    for meth in (BigM(100), Hull())
+        m = GDPModel(paj)
+        set_attribute(m, MOI.Silent(), true)
+        @variable(m, -10 <= x <= 10)
+        @variable(m, -10 <= y <= 10)
+        @variable(m, Y[1:2], Logical)
+        @objective(m, Min, x)
+        @constraint(m, c1, [1, x, y] in SecondOrderCone(), Disjunct(Y[1]))
+        @constraint(m, c2, [1, x - 5, y] in SecondOrderCone(), Disjunct(Y[2]))
+        @disjunction(m, Y)
+        @test optimize!(m, gdp_method = meth) isa Nothing
+        @test termination_status(m) == MOI.OPTIMAL
+        @test isapprox(objective_value(m), -1, atol = 1e-4)
+        @test isapprox(value(x), -1, atol = 1e-4)
+        @test isapprox(value(y), 0, atol = 1e-4)
+        @test value(Y[1])
+        @test !value(Y[2])
+    end
+end
+
+@testset "Solve Conic GDP" begin
+    test_conic_gdp_example()
 end


### PR DESCRIPTION
Adding some conic constraints that can be handled with BigM and Hull. Some things I found odd that maybe you can comment on or correct me.

1) Hull reformulation is standard throughout all cones, but cones in MOI inherit from `AbstractVectorSet`, so I can't just ask for any cone. Right now I'm stuck naming each type of cone rather than a generic `MOI.Cone` datatype.

2) BigM reformulation looks like it needs to be adapted per cone type, and right now I'm kind of having to reason out the correct direction based on the table provided in the paper. Snippet from the paper below.

<img width="816" height="398" alt="image" src="https://github.com/user-attachments/assets/df95ab5a-b366-468a-9280-da03e250a313" />

Overall a good introduction to cones but I just can't get past these two things while I was trying to generalize the code.